### PR TITLE
Python 3.7 support

### DIFF
--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -11,7 +11,7 @@ jobs:
     container: tttapa/alpaqa-build-python-gcc:${{ matrix.python-version }}-11
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10']
+        python-version: ['3.7', '3.8', '3.9', '3.10']
     
     steps:
     - uses: actions/checkout@v1
@@ -39,7 +39,7 @@ jobs:
     container: python:${{ matrix.python-version }}-bullseye
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10']
+        python-version: ['3.7', '3.8', '3.9', '3.10']
     steps:
     - uses: actions/checkout@v1
     - uses: actions/download-artifact@v2
@@ -57,7 +57,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10']
+        python-version: ['3.7', '3.8', '3.9', '3.10']
 
     steps:
     - uses: actions/checkout@v2
@@ -90,7 +90,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10']
+        python-version: ['3.7', '3.8', '3.9', '3.10']
     steps:
     - uses: actions/checkout@v1
     - uses: actions/setup-python@v2
@@ -112,7 +112,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10']
+        python-version: ['3.7', '3.8', '3.9', '3.10']
 
     steps:
     - uses: actions/checkout@v2
@@ -142,7 +142,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10']
+        python-version: ['3.7', '3.8', '3.9', '3.10']
     steps:
     - uses: actions/checkout@v1
     - uses: actions/setup-python@v2

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-py-venv
+py*-venv
 build
 .build
 .*cache

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ and tell py-build-cmake how to build your project. For example:
 [project] # Project metadata
 name = "example-project"
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.7"
 license = { "file" = "LICENSE" }
 authors = [{ "name" = "Pieter P", "email" = "pieter.p.dev@outlook.com" }]
 keywords = ["some", "keywords"]

--- a/examples/minimal-program/pyproject.toml
+++ b/examples/minimal-program/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = []
 dynamic = ["version", "description"]
 
 [build-system]
-requires = ["py-build-cmake~=0.0.11"]
+requires = ["py-build-cmake~=0.0.11.post1"]
 build-backend = "py_build_cmake.build"
 
 [tool.py-build-cmake.module]

--- a/examples/minimal-program/pyproject.toml
+++ b/examples/minimal-program/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "minimal-program"
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.7"
 license = { "file" = "LICENSE" }
 authors = [{ "name" = "Pieter P", "email" = "pieter.p.dev@outlook.com" }]
 keywords = ["program", "script", "binary", "executable"]
@@ -9,6 +9,7 @@ classifiers = [
     "Development Status :: 3 - Alpha",
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",

--- a/examples/minimal-program/src-python/minimal_program_module/__init__.py
+++ b/examples/minimal-program/src-python/minimal_program_module/__init__.py
@@ -1,4 +1,4 @@
 """
 A simple, minimal example of building a C++ program using CMake.
 """
-__version__ = '0.0.11'
+__version__ = '0.0.11.post1'

--- a/examples/minimal/README.md
+++ b/examples/minimal/README.md
@@ -117,7 +117,7 @@ If you have other build-time requirements, you can add them to the list.
 [project]
 name = "minimal"
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.7"
 license = { "file" = "LICENSE" }
 authors = [{ "name" = "Pieter P", "email" = "pieter.p.dev@outlook.com" }]
 keywords = ["addition", "subtraction", "pybind11"]
@@ -125,6 +125,7 @@ classifiers = [
     "Development Status :: 3 - Alpha",
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",

--- a/examples/minimal/pyproject.toml
+++ b/examples/minimal/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "minimal"
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.7"
 license = { "file" = "LICENSE" }
 authors = [{ "name" = "Pieter P", "email" = "pieter.p.dev@outlook.com" }]
 keywords = ["addition", "subtraction", "pybind11"]
@@ -9,6 +9,7 @@ classifiers = [
     "Development Status :: 3 - Alpha",
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",

--- a/examples/minimal/pyproject.toml
+++ b/examples/minimal/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = []
 dynamic = ["version", "description"]
 
 [build-system]
-requires = ["py-build-cmake~=0.0.11"]
+requires = ["py-build-cmake~=0.0.11.post1"]
 build-backend = "py_build_cmake.build"
 
 [tool.py-build-cmake.module]

--- a/examples/minimal/src-python/minimal/__init__.py
+++ b/examples/minimal/src-python/minimal/__init__.py
@@ -1,4 +1,4 @@
 """
 A simple, minimal example of building a Python C module using CMake.
 """
-__version__ = '0.0.11'
+__version__ = '0.0.11.post1'

--- a/examples/pybind11-project/CMakeLists.txt
+++ b/examples/pybind11-project/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.17)
 project(py-build-cmake VERSION 0.0.11)
-set(PY_VERSION_SUFFIX "")
+set(PY_VERSION_SUFFIX ".post1")
 set(PY_FULL_VERSION ${PROJECT_VERSION}${PY_VERSION_SUFFIX})
 
 # Make sure that the Python and CMake versions match

--- a/examples/pybind11-project/pyproject.toml
+++ b/examples/pybind11-project/pyproject.toml
@@ -25,7 +25,7 @@ dynamic = ["version", "description"]
 add = "pybind11_project.add:main"
 
 [build-system]
-requires = ["py-build-cmake~=0.0.11", "pybind11", "pybind11-stubgen"]
+requires = ["py-build-cmake~=0.0.11.post1", "pybind11", "pybind11-stubgen"]
 build-backend = "py_build_cmake.build"
 
 [tool.py-build-cmake.module]

--- a/examples/pybind11-project/pyproject.toml
+++ b/examples/pybind11-project/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "pybind11-project" # Name on PyPI
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.7"
 license = { "file" = "LICENSE" }
 authors = [{ "name" = "Pieter P", "email" = "pieter.p.dev@outlook.com" }]
 keywords = ["addition", "subtraction", "pybind11"]
@@ -9,6 +9,7 @@ classifiers = [
     "Development Status :: 3 - Alpha",
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",

--- a/examples/pybind11-project/python-src/pybind11_project/__init__.py
+++ b/examples/pybind11-project/python-src/pybind11_project/__init__.py
@@ -1,2 +1,2 @@
 """Example project using the py-build-cmake build backend and pybind11."""
-__version__ = '0.0.11'
+__version__ = '0.0.11.post1'

--- a/examples/pybind11-project/test/test_add_module.py
+++ b/examples/pybind11-project/test/test_add_module.py
@@ -8,10 +8,13 @@ def test_add():
 from pybind11_project import __version__ as py_version
 from pybind11_project.add_module import __version__ as py_cpp_version
 from pybind11_project._add_module import __version__ as cpp_version
-from importlib.metadata import version
 
 
 def test_version():
     assert py_version == py_cpp_version
     assert py_version == cpp_version
-    assert py_version == version('pybind11_project')
+    try: # No importlib in Python 3.7 and below
+        from importlib.metadata import version
+        assert py_version == version('pybind11_project')
+    except ImportError:
+        pass

--- a/noxfile.py
+++ b/noxfile.py
@@ -11,7 +11,7 @@ def example_projects(session: nox.Session):
         session.run("python", "-m", "build", ".")
         dist_dir = "dist"
     session.env["PIP_FIND_LINKS"] = os.path.abspath(dist_dir)
-    session.install("py-build-cmake~=0.0.11")
+    session.install("py-build-cmake~=0.0.11.post1")
     with session.chdir("examples/minimal"):
         shutil.rmtree('.py-build-cmake_cache', ignore_errors=True)
         session.run("python", "-m", "build", ".")
@@ -37,7 +37,7 @@ def editable(session: nox.Session):
         session.run("python", "-m", "build", ".")
         dist_dir = "dist"
     session.env["PIP_FIND_LINKS"] = os.path.abspath(dist_dir)
-    session.install("py-build-cmake~=0.0.11")
+    session.install("py-build-cmake~=0.0.11.post1")
     with session.chdir("examples/pybind11-project"):
         shutil.rmtree('.py-build-cmake_cache', ignore_errors=True)
         session.install("-e", ".")
@@ -50,7 +50,7 @@ def tests(session: nox.Session):
     dist_dir = os.getenv('PY_BUILD_CMAKE_WHEEL_DIR')
     if dist_dir:
         session.env["PIP_FIND_LINKS"] = os.path.abspath(dist_dir)
-        session.install("py-build-cmake~=0.0.11")
+        session.install("py-build-cmake~=0.0.11.post1")
     else:
         session.install(".")
     session.run('pytest')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["distlib", "flit"]
+requires = ["distlib~=0.3", "flit~=3.7"]
 build-backend = "py_build_cmake.build"
 backend-path = ["src"]
 
@@ -22,7 +22,7 @@ classifiers = [
     "Operating System :: Microsoft :: Windows",
     "Operating System :: MacOS",
 ]
-dependencies = ["distlib~=0.3", "flit~=3.7"]
+dependencies = ["distlib~=0.3", "flit~=3.7", "packaging~=21.0"]
 dynamic = ["version", "description"]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["distlib~=0.3", "flit~=3.7"]
+requires = ["distlib", "flit"]
 build-backend = "py_build_cmake.build"
 backend-path = ["src"]
 
@@ -22,7 +22,7 @@ classifiers = [
     "Operating System :: Microsoft :: Windows",
     "Operating System :: MacOS",
 ]
-dependencies = ["distlib~=0.3", "flit~=3.7", "packaging~=21.0"]
+dependencies = ["distlib~=0.3", "flit~=3.7"]
 dynamic = ["version", "description"]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ backend-path = ["src"]
 [project]
 name = "py-build-cmake"
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.7"
 license = { "file" = "LICENSE" }
 authors = [{ "name" = "Pieter P", "email" = "pieter.p.dev@outlook.com" }]
 keywords = ["pep517", "cmake"]
@@ -14,6 +14,7 @@ classifiers = [
     "Development Status :: 4 - Beta",
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
     "Operating System :: Microsoft :: Windows",
     "Operating System :: MacOS",
 ]
-dependencies = ["distlib~=0.3", "flit~=3.7"]
+dependencies = ["distlib~=0.3.5", "flit~=3.7"]
 dynamic = ["version", "description"]
 
 [project.urls]

--- a/src/py_build_cmake/__init__.py
+++ b/src/py_build_cmake/__init__.py
@@ -2,4 +2,4 @@
 Modern, PEP 517 compliant build backend for building Python packages with
 extensions built using CMake.
 """
-__version__ = '0.0.11'
+__version__ = '0.0.11.post1'

--- a/src/py_build_cmake/build.py
+++ b/src/py_build_cmake/build.py
@@ -553,8 +553,16 @@ class _BuildBackend(object):
         tags = None
         if cfg.cross:
             tags = self.get_cross_tags(cfg.cross)
-        if pure:
+        elif pure:
             tags = {'pyver': ['py3']}
+        else:
+            import packaging.tags
+            tag = next(packaging.tags.sys_tags())
+            tags = {
+                'pyver': [tag.interpreter],
+                'abi': [tag.abi],
+                'arch': [tag.platform],
+            }
         wheel_path = whl.build(paths, tags=tags, wheel_version=(1, 0))
         whl_name = os.path.relpath(wheel_path, wheel_directory)
         return whl_name

--- a/src/py_build_cmake/build.py
+++ b/src/py_build_cmake/build.py
@@ -552,16 +552,8 @@ class _BuildBackend(object):
         tags = None
         if cfg.cross:
             tags = self.get_cross_tags(cfg.cross)
-        elif pure:
+        if pure:
             tags = {'pyver': ['py3']}
-        else:
-            import packaging.tags
-            tag = next(packaging.tags.sys_tags())
-            tags = {
-                'pyver': [tag.interpreter],
-                'abi': [tag.abi],
-                'arch': [tag.platform],
-            }
         wheel_path = whl.build(paths, tags=tags, wheel_version=(1, 0))
         whl_name = os.path.relpath(wheel_path, wheel_directory)
         return whl_name

--- a/src/py_build_cmake/build.py
+++ b/src/py_build_cmake/build.py
@@ -437,7 +437,8 @@ class _BuildBackend(object):
         builddir = builddir.resolve()
         # Environment variables
         cmake_env = os.environ.copy()
-        if (f := 'env') in cmake_cfg:
+        f = 'env'
+        if f in cmake_cfg:
             for k, v in cmake_cfg[f].items():
                 cmake_env[k] = Template(v).substitute(cmake_env)
 
@@ -476,9 +477,11 @@ class _BuildBackend(object):
         configure_cmd += cmake_cfg.get('args', [])  # User-supplied arguments
         for k, v in cmake_cfg.get('options', {}).items():  # -D {option}={val}
             configure_cmd += ['-D', k + '=' + v]
-        if btype := cmake_cfg.get('build_type'):  # -D CMAKE_BUILD_TYPE={type}
+        btype = cmake_cfg.get('build_type')
+        if btype:  # -D CMAKE_BUILD_TYPE={type}
             configure_cmd += ['-D', 'CMAKE_BUILD_TYPE=' + btype]
-        if gen := cmake_cfg.get('generator'):  # -G {generator}
+        gen = cmake_cfg.get('generator')
+        if gen:  # -G {generator}
             configure_cmd += ['-G', gen]
         self.run(configure_cmd, check=True, env=cmake_env)
 
@@ -517,7 +520,8 @@ class _BuildBackend(object):
         build_cmd += cmake_cfg.get('build_args', [])  # User-supplied arguments
         if config:  # --config {config}
             build_cmd += ['--config', config]
-        if (f := 'build_tool_args') in cmake_cfg:
+        f = 'build_tool_args'
+        if f in cmake_cfg:
             build_cmd += ['--'] + cmake_cfg[f]
         self.run(build_cmd, check=True, env=cmake_env)
 

--- a/src/py_build_cmake/build.py
+++ b/src/py_build_cmake/build.py
@@ -374,11 +374,8 @@ class _BuildBackend(object):
             _vars = _mod.__dict__.copy()
             for _k in ['{"','".join(special_dunders)}']: _vars.pop(_k)
             globals().update(_vars)
-            del _k
-            del _spec
-            del _mod
-            del _vars
-            del _util
+            # Clean up
+            del _k, _spec, _mod, _vars, _util
             """
         (tmp_pkg / '__init__.py').write_text(textwrap.dedent(content),
                                              encoding='utf-8')

--- a/src/py_build_cmake/build.py
+++ b/src/py_build_cmake/build.py
@@ -417,7 +417,7 @@ class _BuildBackend(object):
         args += cfg.get('files', [])
         # Add output folder argument if not already specified in cfg['args']
         if 'args' not in cfg or not ({'-o', '--output'} & set(cfg['args'])):
-            args += ['-o', staging_dir]
+            args += ['-o', str(staging_dir)]
         env = os.environ.copy()
         env.setdefault('MYPY_CACHE_DIR', str(tmp_build_dir))
         # Call mypy stubgen in a subprocess

--- a/src/py_build_cmake/config.py
+++ b/src/py_build_cmake/config.py
@@ -59,7 +59,8 @@ def check_config(pyproject_path, pyproject, localcfg, crosscfg):
 
     # Check the package/module name and normalize it
     from distlib.util import normalize_name
-    if (f := 'name') in pyproject['project']:
+    f = 'name'
+    if f in pyproject['project']:
         normname = normalize_name(pyproject['project'][f])
         if pyproject['project'][f] != normname:
             raise RuntimeWarning(
@@ -98,7 +99,8 @@ def check_config(pyproject_path, pyproject, localcfg, crosscfg):
     tool_cfg = dictcfg['pyproject.toml']['tool']['py-build-cmake']
 
     # Store the module configuration
-    if (s := 'module') in tool_cfg:
+    s = 'module'
+    if s in tool_cfg:
         # Normalize the import and wheel name of the package
         normname = normalize_name_wheel(tool_cfg[s]['name'])
         if tool_cfg[s]['name'] != normname:
@@ -120,7 +122,8 @@ def check_config(pyproject_path, pyproject, localcfg, crosscfg):
         os: get_sdist_cludes(tool_cfg[os])
         for os in ("linux", "windows", "mac")
     }
-    if (s := 'cross') in tool_cfg:
+    s = 'cross'
+    if s in tool_cfg:
         cfg.sdist.update({
             'cross': get_sdist_cludes(tool_cfg[s]),
         })
@@ -133,13 +136,16 @@ def check_config(pyproject_path, pyproject, localcfg, crosscfg):
     }
 
     # Store stubgen configuration
-    if (s := 'stubgen') in tool_cfg:
+    s = 'stubgen'
+    if s in tool_cfg:
         cfg.stubgen = tool_cfg[s]
 
     # Store the cross compilation configuration
-    if (s := 'cross') in tool_cfg:
+    s = 'cross'
+    if s in tool_cfg:
         cfg.cross = tool_cfg[s]
-        if (f := 'copy_from_native_build') in cfg.cross:
+        f = 'copy_from_native_build'
+        if f in cfg.cross:
             cfg.cross[f] = _check_glob_patterns(cfg.cross[f], f'cross.{f}')
         cfg.cmake.update({
             'cross': cfg.cross.pop('cmake', {}),

--- a/src/py_build_cmake/config_options.py
+++ b/src/py_build_cmake/config_options.py
@@ -287,7 +287,8 @@ class ConfigOption:
         superpth = self.inherit_from
         if superpth is not None:
             # If the super option is not set, there's nothing to inherit
-            if (supercfg := cfg.get(superpth)) is None:
+            supercfg = cfg.get(superpth)
+            if supercfg is None:
                 return
 
             # If this option is not set, but the super option is,
@@ -300,7 +301,8 @@ class ConfigOption:
                 return
 
             # Find the option we inherit from and make sure it exists
-            if (superopt := rootopts.get(superpth)) is None:
+            superopt = rootopts.get(superpth)
+            if superopt is None:
                 raise ValueError(f'{pth2str(superpth)} is not a valid option')
 
             # Create a copy of the config of our super-option and override it
@@ -331,7 +333,8 @@ class ConfigOption:
         for s in selfpth:
             p += s,
             opt = opt[s]
-            if (selfcfg := cfg.get(p)) is None:
+            selfcfg = cfg.get(p)
+            if selfcfg is None:
                 if not opt.create_if_inheritance_target_exists:
                     return None
                 create_paths.append(p)
@@ -374,9 +377,10 @@ class ConfigOption:
         selfcfg = cfg[cfgpath]
         # Check if there are any unknown options in the config
         if not self.allow_unknown_keys:
-            if (unkwn := set(selfcfg.sub or ()) - set(self.sub or ())):
+            unknwn = set(selfcfg.sub or ()) - set(self.sub or ())
+            if unknwn:
                 raise ConfigError(f'Unkown options in {pth2str(cfgpath)}: ' +
-                                  ', '.join(unkwn))
+                                  ', '.join(unknwn))
         # Recursively verify the sub-options
         if selfcfg.sub:
             for name, sub in selfcfg.sub.items():
@@ -416,7 +420,8 @@ class ConfigOption:
 
         result = None
         # If the entire path exists in cfg, simply return that value
-        if (cfgval := cfg.get(cfgpath)) is not None:
+        cfgval = cfg.get(cfgpath)
+        if cfgval is not None:
             result = cfgval
         # If the path is not yet in cfg
         else:
@@ -633,7 +638,8 @@ class OverrideConfigOption(ConfigOption):
 
     def override(self, rootopts: ConfigOption, cfg: ConfigNode,
                  cfgpath: ConfPath):
-        if (selfcfg := cfg.get(cfgpath, None)) is None:
+        selfcfg = cfg.get(cfgpath, None)
+        if selfcfg is None:
             return
         elif selfcfg.value is None and selfcfg.sub is None:
             return

--- a/src/py_build_cmake/help/__main__.py
+++ b/src/py_build_cmake/help/__main__.py
@@ -75,9 +75,11 @@ def recursive_help_print(opt: ConfigOption, level=0):
             recursive_help_print(v, level + 1)
         else:
             headerfields = []
-            if (typename := v.get_typename()) is not None:
+            typename = v.get_typename()
+            if typename is not None:
                 headerfields += [typename]
-            if is_required := isinstance(v.default, RequiredValue):
+            is_required = isinstance(v.default, RequiredValue)
+            if is_required:
                 headerfields += ['required']
             if v.inherit_from:
                 headerfields += ['inherits from /' + pth2str(v.inherit_from)]


### PR DESCRIPTION
Removes uses of the walrus operator (`:=`) and makes `importlib` in tests optional.