### PR TITLE
use environmental variable to include config files

### DIFF
--- a/docs/Config.md
+++ b/docs/Config.md
@@ -127,3 +127,13 @@ The same flag may appear multiple times, for example:
 python -m build . -C--local=conf-A.toml -C--local=conf-B.toml
 ```
 For PyPA pip, you can use the `--config-settings` flag instead.
+
+You may also use `PY_BUILD_CMAKE_LOCAL` or `PY_BUILD_CMAKE_CROSS` environmental variables to include additional config files:
+
+```sh
+PY_BUILD_CMAKE_CROSS=/path/to/my-cross-config.toml python -m build .
+```
+You may add multiple config files, using semicolon to separate their paths:
+```sh
+PY_BUILD_CMAKE_LOCAL=conf-A.toml;conf-B.toml python -m build .
+```

--- a/src/py_build_cmake/build.py
+++ b/src/py_build_cmake/build.py
@@ -151,14 +151,6 @@ class _BuildBackend(object):
                 key: listify(config_settings.get(key) or [])
                 for key in keys
             }
-            local_env = list()
-            if os.getenv("PY_BUILD_CMAKE_LOCAL"):
-                local_env = os.getenv("PY_BUILD_CMAKE_LOCAL").split(';')
-            cross_env = list()
-            if os.getenv("PY_BUILD_CMAKE_CROSS"):
-                cross_env = os.getenv("PY_BUILD_CMAKE_CROSS").split(';')
-            overrides['--local'] += local_env
-            overrides['--cross'] += cross_env
             if verbose:
                 print("Configuration settings for local and "
                       "cross-compilation overrides:")

--- a/src/py_build_cmake/build.py
+++ b/src/py_build_cmake/build.py
@@ -151,6 +151,14 @@ class _BuildBackend(object):
                 key: listify(config_settings.get(key) or [])
                 for key in keys
             }
+            local_env = list()
+            if os.getenv("PY_BUILD_CMAKE_LOCAL"):
+                local_env = os.getenv("PY_BUILD_CMAKE_LOCAL").split(';')
+            cross_env = list()
+            if os.getenv("PY_BUILD_CMAKE_CROSS"):
+                cross_env = os.getenv("PY_BUILD_CMAKE_CROSS").split(';')
+            overrides['--local'] += local_env
+            overrides['--cross'] += cross_env
             if verbose:
                 print("Configuration settings for local and "
                       "cross-compilation overrides:")

--- a/src/py_build_cmake/cli.py
+++ b/src/py_build_cmake/cli.py
@@ -1,7 +1,7 @@
 from . import __version__
 from pathlib import Path
 import click
-
+import os
 
 def cmake_command(directory, build_path, verbose, dry, native, cross, local):
 
@@ -9,10 +9,20 @@ def cmake_command(directory, build_path, verbose, dry, native, cross, local):
         from .build import _BuildBackend as backend
         from .datastructures import PackageInfo
         from .cmd_runner import CommandRunner
+        local_list = list(local)
+        if os.getenv("PY_BUILD_CMAKE_LOCAL"):
+            for i in os.getenv("PY_BUILD_CMAKE_LOCAL").split(';'):
+                local_list.append(Path(i))
+        
+        cross_list = list(cross)
+        if os.getenv("PY_BUILD_CMAKE_CROSS"):
+            for i in os.getenv("PY_BUILD_CMAKE_CROSS").split(';'):
+                cross_list.append(Path(i))
+
         source_dir = Path(directory or '.').resolve()
         config_settings = {
-            "--cross": list(cross),
-            "--local": list(local),
+            "--cross": cross_list,
+            "--local": local_list,
         }
         # Read configuration and package metadata
         cfg, pkg, metadata = backend.read_all_metadata(source_dir,

--- a/src/py_build_cmake/cli.py
+++ b/src/py_build_cmake/cli.py
@@ -13,13 +13,16 @@ def cmake_command(directory, build_path, verbose, dry, native, cross, local):
         cross_env = list()
         if os.getenv("PY_BUILD_CMAKE_CROSS"):
             cross_env = os.getenv("PY_BUILD_CMAKE_CROSS").split(';')
+        print(f'{cross_env = }')
         local_env = list()
         if os.getenv("PY_BUILD_CMAKE_LOCAL"):
             local_env = os.getenv("PY_BUILD_CMAKE_LOCAL").split(';')
+        print(f'{local_env = }')
         config_settings = {
             "--cross": list(cross) + cross_env,
             "--local": list(local) + local_env,
         }
+        print(config_settings)
         # Read configuration and package metadata
         cfg, pkg, metadata = backend.read_all_metadata(source_dir,
                                                        config_settings,
@@ -38,6 +41,7 @@ def cmake_command(directory, build_path, verbose, dry, native, cross, local):
         cmake_cfg, native_cmake_cfg = backend.get_cmake_configs(cfg)
         cmake_cfg = native_cmake_cfg if native else cmake_cfg
         cross_cfg = None if native else cfg.cross
+        print(f'{cfg.cross = }')
         # Override the build folder
         if build_path is not None:
             cmake_cfg['build_path'] = str(build_path)

--- a/src/py_build_cmake/cli.py
+++ b/src/py_build_cmake/cli.py
@@ -1,7 +1,7 @@
 from . import __version__
 from pathlib import Path
 import click
-
+import os
 
 def cmake_command(directory, build_path, verbose, dry, native, cross, local):
 
@@ -14,6 +14,10 @@ def cmake_command(directory, build_path, verbose, dry, native, cross, local):
             "--cross": list(cross),
             "--local": list(local),
         }
+        if os.getenv("PY_BUILD_CMAKE_CROSS"):
+            cross += os.getenv("PY_BUILD_CMAKE_CROSS").split(';')
+        if os.getenv("PY_BUILD_CMAKE_LOCAL"):
+            local += os.getenv("PY_BUILD_CMAKE_LOCAL").split(';')
         # Read configuration and package metadata
         cfg, pkg, metadata = backend.read_all_metadata(source_dir,
                                                        config_settings,

--- a/src/py_build_cmake/cli.py
+++ b/src/py_build_cmake/cli.py
@@ -10,14 +10,16 @@ def cmake_command(directory, build_path, verbose, dry, native, cross, local):
         from .datastructures import PackageInfo
         from .cmd_runner import CommandRunner
         source_dir = Path(directory or '.').resolve()
-        config_settings = {
-            "--cross": list(cross),
-            "--local": list(local),
-        }
+        cross_env = list()
         if os.getenv("PY_BUILD_CMAKE_CROSS"):
-            cross += os.getenv("PY_BUILD_CMAKE_CROSS").split(';')
+            cross_env = os.getenv("PY_BUILD_CMAKE_CROSS").split(';')
+        local_env = list()
         if os.getenv("PY_BUILD_CMAKE_LOCAL"):
-            local += os.getenv("PY_BUILD_CMAKE_LOCAL").split(';')
+            local_env = os.getenv("PY_BUILD_CMAKE_LOCAL").split(';')
+        config_settings = {
+            "--cross": list(cross) + cross_env,
+            "--local": list(local) + local_env,
+        }
         # Read configuration and package metadata
         cfg, pkg, metadata = backend.read_all_metadata(source_dir,
                                                        config_settings,

--- a/src/py_build_cmake/cli.py
+++ b/src/py_build_cmake/cli.py
@@ -1,7 +1,7 @@
 from . import __version__
 from pathlib import Path
 import click
-import os
+
 
 def cmake_command(directory, build_path, verbose, dry, native, cross, local):
 
@@ -10,19 +10,10 @@ def cmake_command(directory, build_path, verbose, dry, native, cross, local):
         from .datastructures import PackageInfo
         from .cmd_runner import CommandRunner
         source_dir = Path(directory or '.').resolve()
-        cross_env = list()
-        if os.getenv("PY_BUILD_CMAKE_CROSS"):
-            cross_env = os.getenv("PY_BUILD_CMAKE_CROSS").split(';')
-        print(f'{cross_env = }')
-        local_env = list()
-        if os.getenv("PY_BUILD_CMAKE_LOCAL"):
-            local_env = os.getenv("PY_BUILD_CMAKE_LOCAL").split(';')
-        print(f'{local_env = }')
         config_settings = {
-            "--cross": list(cross) + cross_env,
-            "--local": list(local) + local_env,
+            "--cross": list(cross),
+            "--local": list(local),
         }
-        print(config_settings)
         # Read configuration and package metadata
         cfg, pkg, metadata = backend.read_all_metadata(source_dir,
                                                        config_settings,
@@ -41,7 +32,6 @@ def cmake_command(directory, build_path, verbose, dry, native, cross, local):
         cmake_cfg, native_cmake_cfg = backend.get_cmake_configs(cfg)
         cmake_cfg = native_cmake_cfg if native else cmake_cfg
         cross_cfg = None if native else cfg.cross
-        print(f'{cfg.cross = }')
         # Override the build folder
         if build_path is not None:
             cmake_cfg['build_path'] = str(build_path)


### PR DESCRIPTION
This PR allows using `PY_BUILD_CMAKE_LOCAL` or `PY_BUILD_CMAKE_CROSS` environmental variables to include additional config files. For example:

```sh
PY_BUILD_CMAKE_CROSS=/path/to/my-cross-config.toml python -m build .
```
To add multiple config files, use semicolon to separate their paths:
```sh
PY_BUILD_CMAKE_LOCAL=conf-A.toml;conf-B.toml python -m build .
```

This would help with https://github.com/pypa/cibuildwheel/pull/1557