### PR TITLE
Request mypy and cmake as dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,8 @@ dependencies = [
     "flit_core>=3.7,<4",
     "tomli>=1.2.3,<3; python_version < '3.11'",
     "click~=8.1.3",
+    "mypy",
+    "cmake"
 ]
 dynamic = ["version", "description"]
 


### PR DESCRIPTION
Put cmake as dependency since it is small and it makes it build even if it is not already present system-wide.

mypy is needed for stubgen (maybe only in linux)