### PR TITLE
Fix docs on include/exclude config args supporting recurive patterns

### DIFF
--- a/docs/Config.md
+++ b/docs/Config.md
@@ -27,8 +27,8 @@ Specifies the files that should be included in the source distribution for this 
 
 | Option | Description | Type | Default |
 |--------|-------------|------|---------|
-| `include` | Files and folders to include in the source distribution. May include the &#x27;\*&#x27; wildcard (but not &#x27;\*\*&#x27; for recursive patterns). | list | `[]` |
-| `exclude` | Files and folders to exclude from the source distribution. May include the &#x27;\*&#x27; wildcard (but not &#x27;\*\*&#x27; for recursive patterns). | list | `[]` |
+| `include` | Files and folders to include in the source distribution. May include the &#x27;\*&#x27; wildcard or &#x27;\*\*&#x27; for recursive patterns. | list | `[]` |
+| `exclude` | Files and folders to exclude from the source distribution. May include the &#x27;\*&#x27; wildcard or &#x27;\*\*&#x27; for recursive patterns. | list | `[]` |
 
 ## cmake
 Defines how to build the project to package. If omitted, py-build-cmake will produce a pure Python package. 


### PR DESCRIPTION
Change the documentation as include/exclude config args already support recursive patterns and the docs says the opposite.

The config parser uses `Path.glob` to parse the pattern here:
https://github.com/tttapa/py-build-cmake/blob/b2f0da78da6620d14fc912891faaa8f15a864acb/src/py_build_cmake/export/sdist.py#L100

And `Path.glob` supports recursive patterns: https://docs.python.org/3/library/pathlib.html#pathlib.Path.glob